### PR TITLE
Feature/server persistent trade list

### DIFF
--- a/Client/Services/SignalRClientService.cs
+++ b/Client/Services/SignalRClientService.cs
@@ -47,35 +47,16 @@ namespace Client.Services
         public Task StartAsync() => _connection.StartAsync();
 
         public async Task SubscribeAsync(string panelId, string ticker)
-    {
-        await EnsureStartAsync();
-        await _connection.InvokeAsync("Subscribe", panelId, ticker);
-        _subscriptions[panelId] = ticker;
-    }
-
-    public async Task UnsubscribeAsync(string panelId)
-    {
-        await EnsureStartAsync();
-        await _connection.InvokeAsync("Unsubscribe", panelId);
-        _subscriptions.TryRemove(panelId, out _);
-    }
-
-        private async Task EnsureStartAsync()
-        {
-            if (_connection.State == HubConnectionState.Disconnected)
-            {
-                try
-                {
-                    await _connection.StartAsync();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"SignalR StartAsync failed: {ex.Message}");
-                    throw;
-                }
-            }
+        {        
+            await _connection.InvokeAsync("Subscribe", panelId, ticker);
+            _subscriptions[panelId] = ticker;
         }
 
+        public async Task UnsubscribeAsync(string panelId)
+        {        
+            await _connection.InvokeAsync("Unsubscribe", panelId);
+            _subscriptions.TryRemove(panelId, out _);
+        }
         private Task ResubscribeAllAsync()
         {
             foreach (var kvp in _subscriptions)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ Server/
 ├── Services/
 │   └── OrderBookSimulator.cs # 호가/체결 데이터 시뮬레이터
 │   └── IOrderBookSimulator.cs
+│   └── ITradeStorage.cs      # Trade 데이터 저장 서비스의 인터페이스
+│   └── FileTradeStorage.cs   # Trade 데이터를 File 형태로 저장하는 서비스
+│   └── TradeHistoryPersistenceService.cs  # ITradeStorage 와 IOrderBookSimulator 을 참조하여, Simulator로 부터 제공받은 Trade 데이터를 백그라운드에서 저장하는 작업을 하는 서비스
 ├── Models/
-│   └── DepthEntry.cs, PrintEntry.cs # 호가/체결 데이터 모델
+│   └── DepthEntry.cs # 호가 데이터 모델
+│   └── PrintEntry.cs # 체결 데이터 모델 (Client 출력용)
+│   └── Trade.cs # 체결 데이터 모델 (저장 용 Entity)
 ├── Program.cs
 ```

--- a/Server/Models/Trade.cs
+++ b/Server/Models/Trade.cs
@@ -1,0 +1,29 @@
+﻿namespace Server.Models
+{
+    public class Trade
+    {
+        public string PanelId { get; set; }
+        // 체결 시간
+        public DateTime Time { get; set; }
+        // 매수/매도 구분
+        public string Side { get; set; }
+        // 해당 체결의 티커
+        public string Ticker { get; set; }
+        // 체결 가격
+        public decimal Price { get; set; }
+        // 체결 수량
+        public decimal Quantity { get; set; }
+
+        public PrintEntry ToPrintEntry()
+        {
+            return new PrintEntry
+            {
+                Time = Time,
+                Side = Side,
+                Ticker = Ticker,
+                Price = Price,
+                Quantity = Quantity
+            };
+        }
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -5,6 +5,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSignalR();
 builder.Services.AddSingleton<IOrderBookSimulator, OrderBookSimulator>();
+builder.Services.AddSingleton<ITradeStorage, FileTradeStorage>();
+builder.Services.AddHostedService<TradeHistoryPersistenceService>();
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("CorsPolicy",

--- a/Server/Services/FileTradeStorage.cs
+++ b/Server/Services/FileTradeStorage.cs
@@ -1,0 +1,32 @@
+﻿using Server.Models;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Server.Services
+{
+    public class FileTradeStorage : ITradeStorage
+    {
+        private readonly string _path = "tradeHistory.json";
+        private readonly JsonSerializerOptions _opts = new() { WriteIndented = false };
+        public async Task<IReadOnlyList<Trade>> LoadAsync()
+        {
+            if (!File.Exists(_path)) return Array.Empty<Trade>();
+            var lines = await File.ReadAllLinesAsync(_path);
+            return lines
+                .Where(l => !string.IsNullOrWhiteSpace(l))
+                .Select(l => JsonSerializer.Deserialize<Trade>(l, _opts)!)
+                .ToList();
+        }
+
+        public async Task SaveAsync(IEnumerable<Trade> trades)
+        {
+            var lines = trades.Select(t => JsonSerializer.Serialize(t, _opts));
+            await File.WriteAllLinesAsync(_path, lines);
+        }
+        public async Task AppendAsync(IEnumerable<Trade> newTrades)
+        {
+            var lines = newTrades.Select(t => JsonSerializer.Serialize(t, _opts));
+            await File.AppendAllLinesAsync(_path, lines);
+        }
+    }
+}

--- a/Server/Services/IOrderBookSimulator.cs
+++ b/Server/Services/IOrderBookSimulator.cs
@@ -4,9 +4,17 @@ namespace Server.Services
 {
     public interface IOrderBookSimulator
     {
+        // Depth 구독/구독 해제
         void SubscribeDepth(string panelId, string ticker, Action<string, DepthEntry[]> depthCallback);
         void UnsubscribeDepth(string panelId);
+        // 화면용 Print 구독/구독 해제
         void SubscribePrint(Action<string, PrintEntry[]> printCallback);
         void UnsubscribePrint(Action<string, PrintEntry[]> printCallback);
+        // DB 저장용 Trade 구독/구독 해제
+        void SubscribeTrade(Action<string, Trade[]> tradeCallback);
+        void UnsubscribeTrade(Action<string, Trade[]> tradeCallback);
+        void InitializeTrades(IEnumerable<Trade> tradeHistory);
+        IReadOnlyList<Trade> GetAllTrades();
+        IReadOnlyList<Trade> GetRecentTrades(int count);
     }
 }

--- a/Server/Services/ITradeStorage.cs
+++ b/Server/Services/ITradeStorage.cs
@@ -1,0 +1,11 @@
+﻿using Server.Models;
+
+namespace Server.Services
+{
+    public interface ITradeStorage
+    {
+        Task SaveAsync(IEnumerable<Trade> trades);
+        Task AppendAsync(IEnumerable<Trade> newTrades);
+        Task<IReadOnlyList<Trade>> LoadAsync();
+    }
+}

--- a/Server/Services/TradeHistoryPersistenceService.cs
+++ b/Server/Services/TradeHistoryPersistenceService.cs
@@ -1,0 +1,49 @@
+﻿
+using Server.Models;
+
+namespace Server.Services
+{
+    public class TradeHistoryPersistenceService : IHostedService, IDisposable
+    {
+        private readonly IOrderBookSimulator _sim;
+        private readonly ITradeStorage _storage;        
+
+        private Action<string, Trade[]> _tradeCallback;
+        private bool _subscribed = false;
+
+        public TradeHistoryPersistenceService(IOrderBookSimulator sim, ITradeStorage storage)
+        {
+            _sim = sim;
+            _storage = storage;
+        }
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            // 로컬 File에 Trade History 가 저장되어있는 것을 Load하여 시뮬레이터에 전달
+            var persistedTrades = await _storage.LoadAsync();
+            _sim.InitializeTrades(persistedTrades);
+
+            _tradeCallback = async (ticker, trades) =>
+            {
+                await _storage.AppendAsync(trades);
+            };
+
+            _sim.SubscribeTrade(_tradeCallback);
+            _subscribed = true;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            // 종료 시점에 메모리에 남은 체결내역 중 최대 100개만 저장
+            var allTrades = _sim.GetRecentTrades(100);
+            await _storage.SaveAsync(allTrades);
+        }
+        public void Dispose()
+        {
+            if (_subscribed)
+            {
+                _sim.UnsubscribeTrade(_tradeCallback);
+                _subscribed = false;
+            }            
+        }
+    }
+}


### PR DESCRIPTION
UI 재실행 시, 기존 체결 내역(Trade 데이터) 가 다시 보여지도록 하기위한 Trade 데이터 저장 서비스 추가
- Trade 데이터를 File 로 저장
- OrderBookHub 의 Subscribe 함수에,  초기 Trade 데이터 읽으면 모두 Client 에게 Send 하는 로직 추가