### PR TITLE
OrderBookPanel UI 수정

### DIFF
--- a/Client/Views/OrderBookPanelView.xaml
+++ b/Client/Views/OrderBookPanelView.xaml
@@ -4,7 +4,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             d:DesignWidth="420" d:DesignHeight="400">
+             d:DesignWidth="420" d:DesignHeight="400"
+             MinWidth="210"
+             Loaded="DepthScroll_LayoutUpdated">
 
     <UserControl.Resources>
         <!-- Ask 용 템플릿-->
@@ -98,13 +100,11 @@
     <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="5" Margin="5">
         <Grid>
             <Grid.RowDefinitions>
-                <!-- 헤더 -->
                 <RowDefinition Height="Auto"/>
                 <!-- Depth (Ask+line+Bid) -->
-                <RowDefinition Height="220"/>
+                <RowDefinition Height="300"/>
             </Grid.RowDefinitions>
 
-            <!-- 헤더 -->
             <DockPanel Grid.Row="0" Margin="0,0,0,5">
                 <TextBlock Text="{Binding Ticker}"
                            FontSize="16" FontWeight="Bold"
@@ -115,16 +115,18 @@
                         DockPanel.Dock="Right"/>
             </DockPanel>
 
-            <!-- Depth 전체 -->
-            <ScrollViewer x:Name="DepthScroll"
-                          Grid.Row="1"
-                          VerticalScrollBarVisibility="Visible">
+            <ScrollViewer x:Name="DepthScroll" 
+                          Grid.Row="1" 
+                          VerticalScrollBarVisibility="Visible" 
+                          Loaded="DepthScroll_LayoutUpdated">
                 <StackPanel>
                     <!-- Ask 10단계 -->
-                    <ItemsControl ItemsSource="{Binding Asks}"
+                    <ItemsControl x:Name="AskItemsControl" 
+                                  ItemsSource="{Binding Asks}" 
                                   ItemTemplate="{StaticResource AskRowTemplate}"/>
                     <!-- Bid 10단계 -->
-                    <ItemsControl ItemsSource="{Binding Bids}"
+                    <ItemsControl x:Name="BidItemsControl" 
+                                  ItemsSource="{Binding Bids}" 
                                   ItemTemplate="{StaticResource BidRowTemplate}"/>
                 </StackPanel>
             </ScrollViewer>

--- a/Client/Views/OrderBookPanelView.xaml.cs
+++ b/Client/Views/OrderBookPanelView.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using System.Windows.Threading;
 
 namespace Client.Views
 {
@@ -23,6 +24,21 @@ namespace Client.Views
         public OrderBookPanelView()
         {
             InitializeComponent();
+            DepthScroll.LayoutUpdated += DepthScroll_LayoutUpdated;
+        }
+
+        private void DepthScroll_LayoutUpdated(object sender, EventArgs e)
+        {
+            // 스크롤 가능한 높이가 0보다 커질 때 = 콘텐츠 크기가 계산 완료된 시점
+            if (DepthScroll.ScrollableHeight > 0)
+            {
+                // 핸들러 제거(한 번만 실행)
+                DepthScroll.LayoutUpdated -= DepthScroll_LayoutUpdated;
+
+                // 중간으로 이동
+                var middle = DepthScroll.ScrollableHeight / 2.0;
+                DepthScroll.ScrollToVerticalOffset(middle);
+            }
         }
     }
 }


### PR DESCRIPTION
- SignalR Client로부터 호가 데이터를  받기 전/후의 panel 너비 차이가 큰 현상 수정
- 초기 Panel 추가 시,  스크롤이 20개의 호가 중 중간에 위치되도록 변경
- Panel 의 높이 더 크게 수정